### PR TITLE
feat(ci): add goreleaser for multi-platform binary releases

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -4,34 +4,64 @@ on:
       - master
       - develop
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      versionOut: ${{ steps.generateVersion.outputs.version }}
+      versionOut: ${{ steps.out.outputs.version }}
+      published: ${{ steps.semrel.outputs.new-release-published }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: paulhatch/semantic-version@9f72830310d5ed81233b641ee59253644cd8a8fc # v6.0.2
-        id: generateVersion
+      - name: Semantic release
+        id: semrel
+        if: github.ref == 'refs/heads/master'
+        uses: go-semantic-release/action@7ae13e11e9bbf82b4b715f75bdb95f3ad84c3fd3 # v1.23.0
         with:
-          tag_prefix: "v"
-          major_pattern: "(MAJOR)"
-          minor_pattern: "(MINOR)"
-          bump_each_commit: false
-          enable_prerelease_mode: true
-          version_format: "${major}.${minor}.${patch}"
-      - name: Create & push tag
-        if: github.ref == 'refs/heads/master' && steps.generateVersion.outputs.is_tagged == 'false'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-initial-development-versions: false
+          changelog-generator-opt: "emojis=true"
+      - name: Fallback develop version
+        id: dev
+        if: github.ref != 'refs/heads/master'
+        run: echo "version=0.0.0-develop-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - name: Emit version
+        id: out
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          TAG="${{ steps.generateVersion.outputs.version_tag }}"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-  
+          if [ "${{ steps.semrel.outputs.new-release-published }}" = "true" ]; then
+            echo "version=${{ steps.semrel.outputs.new-release-version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ steps.dev.outputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  goreleaser:
+    runs-on: ubuntu-latest
+    needs: version
+    if: github.ref == 'refs/heads/master' && needs.version.outputs.published == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: v${{ needs.version.outputs.versionOut }}
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   backend:
     strategy:
       matrix:
@@ -43,6 +73,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs:
       - version
+    if: needs.version.outputs.versionOut != '' && (github.ref != 'refs/heads/master' || needs.version.outputs.published == 'true')
     env:
       DOCKER_SERVER_IMAGE_NAME: "ghcr.io/${{ github.repository }}/temp-backend:${{needs.version.outputs.versionOut}}-${{ matrix.arch }}"
     steps:
@@ -52,10 +83,9 @@ jobs:
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: VERSION=${{needs.version.outputs.versionOut}} COMMIT_SHA=${GITHUB_SHA::7} make build-docker
       - run: docker push ${DOCKER_SERVER_IMAGE_NAME}
-  
+
   backend-multi-arch:
     runs-on: ubuntu-latest
     needs:
@@ -84,6 +114,7 @@ jobs:
     container: node:24-alpine
     needs:
       - version
+    if: needs.version.outputs.versionOut != '' && (github.ref != 'refs/heads/master' || needs.version.outputs.published == 'true')
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -137,7 +168,7 @@ jobs:
     env:
       DOCKER_FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/go-money-full"
       DOCKER_FULL_IMAGE_NAME_LATEST: "ghcr.io/${{ github.repository }}/go-money-full:latest"
-      
+
       DOCKER_TEMP_FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/temp-full:${{needs.version.outputs.versionOut}}"
     steps:
       - name: Checkout code
@@ -158,14 +189,14 @@ jobs:
           else
             TAGS=("develop")
           fi
-                    
+
           for TAG in "${TAGS[@]}"; do
             FULL_TAG="${DOCKER_FULL_IMAGE_NAME}:${TAG}"
-          
+
             docker manifest create "${FULL_TAG}" \
               "${DOCKER_TEMP_FULL_IMAGE_NAME}-linux-amd64" \
               "${DOCKER_TEMP_FULL_IMAGE_NAME}-linux-arm64"
-          
+
             docker manifest push "${FULL_TAG}"
           done
   helm:
@@ -180,20 +211,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      
+
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-      
+
       - name: Configure Git
         run: |
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: 'gh-pages'
           fetch-depth: '0'
           path: 'gh-pages-dir'
-      
+
       - name: replace versions
         env:
           DOCKER_IMAGE_VERSION: ${{needs.version.outputs.versionOut}}
@@ -210,16 +241,16 @@ jobs:
           cat $CHART_FOLDER/Chart.yaml
           echo "New values.yaml"
           cat $CHART_FOLDER/values.yaml
-      
+
       - name: release
         env:
           CHART_FOLDER: "helm"
           HELM_CHART_VERSION: ${{ needs.version.outputs.versionOut }}
-        
+
         run: |
           helm package $CHART_FOLDER -d gh-pages-dir
           cd gh-pages-dir
-          helm repo index . 
+          helm repo index .
           git add .
           git commit -m "Release chart version $HELM_CHART_VERSION"
           git push origin gh-pages

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,82 @@
+version: 2
+project_name: go-money
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: server
+    main: ./cmd/server
+    binary: go-money-server
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/ft-t/go-money/pkg/boilerplate.version={{.Version}}
+      - -X github.com/ft-t/go-money/pkg/boilerplate.commitSHA={{.ShortCommit}}
+
+  - id: mcp-client
+    main: ./cmd/mcp-client
+    binary: go-money-mcp-client
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commitSHA={{.ShortCommit}}
+
+archives:
+  - id: server
+    ids: [server]
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: "go-money-server_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - README.md
+  - id: mcp-client
+    ids: [mcp-client]
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: "go-money-mcp-client_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - README.md
+      - src: docs/mcp/client-setup.md
+        dst: MCP-CLIENT-SETUP.md
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-SNAPSHOT-{{ .ShortCommit }}"
+
+changelog:
+  disable: true
+
+release:
+  github:
+    owner: ft-t
+    name: go-money
+  mode: append
+  prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,11 @@ mcp-client:
 .PHONY: key-gen
 key-gen:
 	go build -o bin/jwt-key-generator ./cmd/key-gen
+
+.PHONY: goreleaser-snapshot
+goreleaser-snapshot:
+	goreleaser release --snapshot --clean --skip=publish
+
+.PHONY: goreleaser-check
+goreleaser-check:
+	goreleaser check

--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ It enables customizations through Lua scripting and external reporting with Graf
 
 ## Key Features
 
-- Support for multi currency transactions
-- Custom Lua hooks to process transactions
+- Multi-currency transactions with base-currency tracking
+- Double-entry ledger for audit-grade bookkeeping
+- Custom Lua hooks + transaction rules engine to auto-tag, categorize, enrich transactions
 - Grafana-based reporting (bring your own dashboards)
-- Import data from other finance apps (Firefly for now)
+- Tags, categories, hierarchical accounts, daily stats
+- CSV/XLSX imports: Firefly III, Monobank, Privat24, Paribas, Revolut
+- Embedded **MCP server** for AI agents — read-only SQL + domain tools exposed at `/mcp`
 - Scriptable and developer-friendly architecture
-- High test coverage and stable api
-- Multiple client libraries provided via [ConnectRPC](https://buf.build/xskydev/go-money-pb/sdks/main:protobuf) 
+- High test coverage and stable API
+- Multiple client libraries via [ConnectRPC](https://buf.build/xskydev/go-money-pb/sdks/main:protobuf)
+- Prebuilt multi-arch Docker images and standalone binaries (linux/darwin/windows)
 
 ## Demo
 A demo instance of Go Money is available at [https://demo.go-money.top](https://demo.go-money.top) and grafana dashboards at [https://grafana.go-money.top](https://grafana.go-money.top).
@@ -35,7 +39,13 @@ Login credentials for the demo instance:
 `Note3`: The demo instances is running on cheapest 1$ VPS, so it may be slow or unstable at times.
 
 ## Installation
-Go Money is available as a Docker image, making it easy to deploy and run on any system that supports Docker.
+
+Go Money is available as:
+
+- **Docker image** — `ghcr.io/ft-t/go-money/go-money-full:latest` (bundles backend + UI).
+- **Helm chart** — published to `gh-pages` branch.
+- **Standalone binaries** — `go-money-server` + `go-money-mcp-client` for linux/darwin (amd64 + arm64) and windows (amd64), attached to each [GitHub Release](https://github.com/ft-t/go-money/releases).
+
 For detailed installation instructions, please refer to the [Installation guide](https://github.com/ft-t/go-money/wiki/Installation).
 
 ## UI
@@ -55,12 +65,68 @@ Go Money does not come with built-in reports. Instead, it allows you to use Graf
 
 [//]: # ([Grafana dashboards]&#40;https://github.com/ft-t/go-money/tree/master/docs/reporting/dashboards&#41;.)
 
-## Scripting 
-Go Money allows you to write Lua scripts to process transactions. This makes it highly flexible and adaptable to your specific needs.
+## Scripting
+Go Money runs Lua per transaction (via [gopher-lua](https://github.com/yuin/gopher-lua)) to enrich, re-tag, re-categorize, split, or annotate based on your own logic. Scripts live in the DB and hot-reload — no restarts.
+
+Rules engine details: [docs/business-logic/rules-engine/overview.md](docs/business-logic/rules-engine/overview.md).
 
 [Lua scripting guide](https://github.com/ft-t/go-money/wiki/Lua)
 
 [Lua scripts examples](https://github.com/ft-t/go-money/tree/master/docs/lua)
+
+## Imports
+Bring your existing data from other finance apps. Supported formats:
+
+- [Firefly III](https://firefly-iii.org/) export
+- Monobank statement
+- Privat24 xlsx statement
+- Paribas xlsx statement
+- Revolut statement
+
+See [pkg/importers](https://github.com/ft-t/go-money/tree/master/pkg/importers) for the parsers.
+
+## MCP Integration (AI agents)
+
+Go Money ships an embedded [Model Context Protocol](https://modelcontextprotocol.io) server at `/mcp`. Connect any MCP-compatible AI agent (Claude Desktop, Claude Code, Cursor, Windsurf, Zed, etc.) and query your finances in natural language — "how much did I spend on groceries last month?", "what's my net worth trend?", "auto-tag my Uber transactions".
+
+### Tools exposed
+
+| Tool | Purpose |
+|------|---------|
+| `query` | Read-only SQL over the full ledger. Agent-facing docs loaded at boot; see [Query Safety](docs/mcp/query-safety.md). |
+| Tag tools | `list_tags`, `create_tag`, `update_tag`, `delete_tag`. |
+| Category tools | `list_categories`, `create_category`, `update_category`, `delete_category`. |
+| Rule tools | `list_rules`, `create_rule`, `update_rule`, `delete_rule`, `test_rule` — manage Lua transaction rules. |
+| Currency tools | `list_currencies`, `upsert_currency`. |
+| Transaction tools | `list_transactions`, `create_transaction`. |
+
+### Quick start (Claude Desktop / Claude Code)
+
+1. Create a **service token** in *Settings → Service Tokens*.
+2. Download `go-money-mcp-client` from the [latest release](https://github.com/ft-t/go-money/releases).
+3. Add to your agent's MCP config:
+
+   ```json
+   {
+     "mcpServers": {
+       "go-money": {
+         "command": "go-money-mcp-client",
+         "args": ["-server", "https://your-go-money-host/mcp/"],
+         "env": { "GOMONEY_TOKEN": "<paste-token>" }
+       }
+     }
+   }
+   ```
+
+4. Restart the agent. Tools appear under the `go-money` namespace.
+
+### Documentation
+
+- [MCP overview](docs/mcp/overview.md) — purpose, query safety, example SQL.
+- [MCP client setup](docs/mcp/client-setup.md) — full `go-money-mcp-client` flags, env vars, troubleshooting.
+- [MCP tool reference](docs/mcp/tool-reference.md) — per-tool request/response spec.
+- [MCP golden rules](docs/mcp/GOLDEN-RULES.md) — must-read for agents before generating queries.
+- [MCP examples](docs/mcp/examples.md) — 30+ natural-language → SQL mappings.
 
 ## Multi currency support
 Go Money supports multiple currencies, allowing you to manage transactions in different currencies seamlessly.
@@ -71,4 +137,7 @@ Go Money stores additional fields to track amounts in primary currency, so its m
 
 ## Documentation
 
-Full documentation and examples are available in the [Wiki](https://github.com/ft-t/go-money/wiki)
+- [Wiki](https://github.com/ft-t/go-money/wiki) — user-facing guides (install, config, Lua, Grafana).
+- [`docs/`](docs/) — architecture, schema, business logic, MCP. Start at [`docs/INDEX.md`](docs/INDEX.md).
+- [`docs/frontend-architecture.md`](docs/frontend-architecture.md) — Angular SPA patterns.
+- [API documentation](https://github.com/ft-t/go-money/wiki/Api) — ConnectRPC (gRPC + JSON-RPC).

--- a/cmd/mcp-client/main.go
+++ b/cmd/mcp-client/main.go
@@ -15,6 +15,11 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+var (
+	version   = "dev"
+	commitSHA = "none"
+)
+
 type headerFlags []string
 
 func (h *headerFlags) String() string {
@@ -30,12 +35,22 @@ func main() {
 	var headers headerFlags
 
 	serverURL := flag.String("server", "http://localhost:8080/mcp/", "Go Money MCP server URL")
-	token := flag.String("token", "", "Service token for authentication (required)")
+	token := flag.String("token", "", "Service token for authentication (falls back to $GOMONEY_TOKEN)")
 	flag.Var(&headers, "header", "Additional HTTP header in 'Key: Value' format (can be specified multiple times)")
+	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
+	if *showVersion {
+		log.Printf("go-money-mcp-client %s (%s)", version, commitSHA)
+		return
+	}
+
 	if *token == "" {
-		log.Fatal("service token is required: use -token flag")
+		*token = os.Getenv("GOMONEY_TOKEN")
+	}
+
+	if *token == "" {
+		log.Fatal("service token is required: use -token flag or set $GOMONEY_TOKEN")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -79,7 +94,7 @@ func main() {
 		Params: mcp.InitializeParams{
 			ClientInfo: mcp.Implementation{
 				Name:    "go-money-mcp-client",
-				Version: "1.0.0",
+				Version: version,
 			},
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 		},
@@ -95,7 +110,7 @@ func main() {
 
 	stdioServer := server.NewMCPServer(
 		"go-money-mcp-client",
-		"1.0.0",
+		version,
 		server.WithToolCapabilities(true),
 		server.WithResourceCapabilities(true, true),
 	)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -67,8 +67,10 @@
 | Document | Keywords |
 |----------|----------|
 | [MCP Overview](mcp/overview.md) | read-only queries, AI integration |
+| [Client Setup](mcp/client-setup.md) | `go-money-mcp-client` stdio bridge, Claude config, flags, token |
 | [Tool Reference](mcp/tool-reference.md) | query tool spec, parameters, output format |
 | [Query Safety](mcp/query-safety.md) | blocked statements, limits, allowed tables |
+| [Golden Rules](mcp/GOLDEN-RULES.md) | must-read for agents before generating queries |
 | [Examples](mcp/examples.md) | natural language → SQL mappings |
 
 ---

--- a/docs/mcp/client-setup.md
+++ b/docs/mcp/client-setup.md
@@ -1,0 +1,129 @@
+# MCP Client Setup
+
+How to connect an AI agent (Claude Desktop, Claude Code, Cursor, etc.) to the Go Money MCP server.
+
+## Background
+
+Go Money's MCP server is an **HTTP** endpoint at `/mcp` (StreamableHTTP transport). Most local AI agents speak MCP over **stdio** only. Bridge the two with `go-money-mcp-client` — a small Go binary that proxies stdio calls to the remote HTTP server, forwarding a service token for auth.
+
+```
+Agent (stdio) ──► go-money-mcp-client ──HTTPS──► Go Money server /mcp
+```
+
+## Server-side prerequisites
+
+1. Go Money server is running with MCP enabled. Default — it is. To disable, set:
+   ```
+   MCP_DISABLE=true
+   ```
+2. Create a **service token** (the auth credential the bridge will use). Use the Configuration API or the web UI under *Settings → Service Tokens*. The token is a JWT — copy it **once**; it cannot be retrieved later.
+
+Configuration env vars (see `pkg/configuration/types.go`):
+
+| Variable            | Default   | Purpose                                    |
+|---------------------|-----------|--------------------------------------------|
+| `MCP_DISABLE`       | `false`   | Turn the embedded MCP server on/off.       |
+| `MCP_DOCS_DIR`      | `./mcp`   | Folder with MCP guidance docs loaded at boot (shipped with Docker image). |
+
+## Install the client
+
+### From GitHub Releases
+
+Each release publishes `go-money-mcp-client_<version>_<os>_<arch>.{tar.gz|zip}` for:
+
+- `linux_amd64`, `linux_arm64`
+- `darwin_amd64`, `darwin_arm64`
+- `windows_amd64`
+
+Grab the archive from <https://github.com/ft-t/go-money/releases>, extract, and place the binary on your `PATH`.
+
+### From source
+
+```bash
+git clone https://github.com/ft-t/go-money
+cd go-money
+make mcp-client          # builds ./bin/mcp-client
+```
+
+Or directly:
+
+```bash
+go install github.com/ft-t/go-money/cmd/mcp-client@latest
+```
+
+## CLI flags
+
+```
+go-money-mcp-client \
+  -server http://localhost:8080/mcp/ \
+  -token  <service-token>            \
+  -header "X-Something: value"       # optional, repeatable
+```
+
+| Flag       | Default                         | Description                                                 |
+|------------|---------------------------------|-------------------------------------------------------------|
+| `-server`  | `http://localhost:8080/mcp/`    | Full URL to the Go Money MCP endpoint. Include trailing `/`. |
+| `-token`   | — (required)                    | Service token. Falls back to `$GOMONEY_TOKEN` when unset.   |
+| `-header`  | none (repeatable)               | Extra HTTP header, `Key: Value` format.                     |
+| `-version` | —                               | Print version and exit.                                     |
+
+`$GOMONEY_TOKEN` lets you keep the secret out of shell history and config files.
+
+## Wiring into agents
+
+### Claude Desktop / Claude Code
+
+Add to your MCP config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, or `~/.claude/mcp_servers.json` for Claude Code):
+
+```json
+{
+  "mcpServers": {
+    "go-money": {
+      "command": "go-money-mcp-client",
+      "args": [
+        "-server", "https://your-go-money-host/mcp/"
+      ],
+      "env": {
+        "GOMONEY_TOKEN": "eyJhbGciOi..."
+      }
+    }
+  }
+}
+```
+
+Restart the agent. Tools should appear under the `go-money` server.
+
+### Cursor / Windsurf / other stdio MCP clients
+
+Any client that accepts a stdio MCP server command works the same way — point `command` at the binary, pass `-server` in `args`, put the token in `env.GOMONEY_TOKEN`.
+
+## Available tools
+
+The bridge forwards every tool exposed by the server. Current set:
+
+- `query` — read-only SQL against the Postgres DB (see [tool-reference.md](tool-reference.md)).
+- Tags: `list_tags`, `create_tag`, `update_tag`, `delete_tag`.
+- Categories: `list_categories`, `create_category`, `update_category`, `delete_category`.
+- Rules: `list_rules`, `create_rule`, `update_rule`, `delete_rule`, `test_rule`.
+- Currencies: `list_currencies`, `upsert_currency`.
+- Transactions: `list_transactions`, `create_transaction`.
+
+See [tool-reference.md](tool-reference.md) for the authoritative per-tool spec. See [GOLDEN-RULES.md](GOLDEN-RULES.md) for agent guidance before issuing queries.
+
+## Troubleshooting
+
+| Symptom                                      | Cause / fix                                                                 |
+|----------------------------------------------|-----------------------------------------------------------------------------|
+| `service token is required`                  | Set `-token` or `$GOMONEY_TOKEN`.                                           |
+| `failed to create transport: ... x509`       | TLS cert not trusted. Import the CA into your OS trust store.               |
+| 401 Unauthorized                             | Token expired, revoked, or wrong server. Regenerate a service token.        |
+| Client connects but no tools                 | Server's `MCP_DISABLE=true`. Toggle it off and restart.                     |
+| Tools missing after server upgrade           | Restart the agent — stdio client caches tool list on handshake.             |
+| `invalid header format`                      | `-header` must be `Key: Value` with the colon.                              |
+
+## Security notes
+
+- Service tokens inherit permissions of the user that created them — scope them accordingly.
+- Rotate tokens periodically. Revoke compromised ones via the Configuration API.
+- `query` is read-only (SELECT only); mutation tools respect the token's permissions.
+- All agent activity is logged server-side for audit.


### PR DESCRIPTION
## Summary

- Ships `go-money-server` and `go-money-mcp-client` as standalone binaries for linux/darwin (amd64+arm64) and windows (amd64) via goreleaser, attached to every GitHub Release alongside the existing docker images.
- Swaps `paulhatch/semantic-version` for `go-semantic-release/action` so conventional-commit messages auto-bump tags (feat → minor, fix/chore/perf/refactor → patch, docs/ci/style/test/build → skip). Downstream docker + helm jobs now gate on `needs.version.outputs.published == 'true'` on master.
- Documents MCP client setup end-to-end ([`docs/mcp/client-setup.md`](docs/mcp/client-setup.md)) — the stdio↔HTTP bridge, flags, `$GOMONEY_TOKEN` fallback, Claude Desktop / Claude Code config snippet, troubleshooting.
- Expands the README: dedicated **MCP Integration** section (quick-start config, tool table, docs links), full list of importers (Firefly III, Monobank, Privat24, Paribas, Revolut), binary-release install path, rules-engine pointer.
- `cmd/mcp-client` gains a `-version` flag and falls back to `$GOMONEY_TOKEN` when `-token` is unset, so secrets can stay out of shell history.

## Notable details

- Per-binary ldflags: `-X github.com/ft-t/go-money/pkg/boilerplate.version/commitSHA` for server, `-X main.version/commitSHA` for mcp-client.
- Per-id archive blocks so each binary produces its own tarball/zip (10 archives per release, not 5).
- `go-semantic-release` default analyzer will still bump **major** on `BREAKING CHANGE:` footers or `feat!:` syntax. Conventional commits without `!:` never bump major — matches current workflow.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go build ./...` clean
- [x] `goreleaser check` passes
- [x] `make goreleaser-snapshot` produces 10 archives; `go-money-mcp-client -version` prints injected version + commit SHA
- [ ] Merge to master → verify `go-semantic-release` tags, `goreleaser` job uploads binaries to the release, docker flow still passes
- [ ] Download a release binary on macOS/linux and confirm `-server` + `$GOMONEY_TOKEN` wiring works against a live MCP server