### PR TITLE
fix(frontend): port transactions import accordion to PrimeNG 21 API

### DIFF
--- a/frontend/src/app/pages/transactions/transactions-import.component.html
+++ b/frontend/src/app/pages/transactions/transactions-import.component.html
@@ -45,22 +45,32 @@
                     </div>
                 }
 
-                <div class="flex flex-row gap-4">
-                    <p-checkbox id="chkbox1" [(ngModel)]="stagingMode" [binary]="true" />
-                    <label for="chkbox1">Staging Mode (manual approval)</label>
+                <div class="flex flex-row flex-wrap gap-4">
+                    <div class="flex items-center gap-2">
+                        <p-checkbox inputId="chkbox1" [(ngModel)]="stagingMode" [binary]="true" />
+                        <label for="chkbox1">Staging Mode (manual approval)</label>
+                    </div>
 
-                    <p-checkbox id="chkbox2" [(ngModel)]="skipRules" [binary]="true" />
-                    <label for="chkbox2">Skip rules (automation)</label>
+                    <div class="flex items-center gap-2">
+                        <p-checkbox inputId="chkbox2" [(ngModel)]="skipRules" [binary]="true" />
+                        <label for="chkbox2">Skip rules (automation)</label>
+                    </div>
 
-                    <p-checkbox id="chkbox3" [(ngModel)]="treatDatesAsUtc" [binary]="true" />
-                    <label for="chkbox3">Treat Dates as UTC</label>
+                    <div class="flex items-center gap-2">
+                        <p-checkbox inputId="chkbox3" [(ngModel)]="treatDatesAsUtc" [binary]="true" />
+                        <label for="chkbox3">Treat Dates as UTC</label>
+                    </div>
 
-                    <p-checkbox id="chkbox4" [(ngModel)]="skipDuplicateReferenceCheck" [binary]="true" />
-                    <label for="chkbox4">Skip Duplicate Reference Check</label>
+                    <div class="flex items-center gap-2">
+                        <p-checkbox inputId="chkbox4" [(ngModel)]="skipDuplicateReferenceCheck" [binary]="true" />
+                        <label for="chkbox4">Skip Duplicate Reference Check</label>
+                    </div>
 
                     @if (!stagingMode) {
-                        <p-checkbox id="chkbox5" [(ngModel)]="skipValidationErrors" [binary]="true" />
-                        <label for="chkbox5">Skip Validation Errors</label>
+                        <div class="flex items-center gap-2">
+                            <p-checkbox inputId="chkbox5" [(ngModel)]="skipValidationErrors" [binary]="true" />
+                            <label for="chkbox5">Skip Validation Errors</label>
+                        </div>
                     }
                 </div>
                 @if (this.isRawTextImport()) {
@@ -119,10 +129,10 @@
                     </div>
                 </div>
 
-                <p-accordion [multiple]="true" [(activeIndex)]="activeIndices">
+                <p-accordion [multiple]="true" [(value)]="activeValues">
                     @for (item of getFilteredTransactionItems(); track item.transaction; let idx = $index) {
-                        <p-accordionTab [ngClass]="{ 'validation-error': item.hasValidationError }">
-                            <ng-template pTemplate="header">
+                        <p-accordion-panel [value]="idx.toString()" [ngClass]="{ 'validation-error': item.hasValidationError }">
+                            <p-accordion-header>
                                 <div class="flex flex-row gap-3 items-center w-full">
                                     <p-checkbox [(ngModel)]="item.selected" [binary]="true" [disabled]="item.duplicateTxID !== undefined || item.hasError" (click)="$event.stopPropagation()" />
                                     <div class="flex flex-col gap-1 flex-1">
@@ -148,15 +158,17 @@
                                         }
                                     </div>
                                 </div>
-                            </ng-template>
-                            @if (item.hasError) {
-                                <div class="p-4">
-                                    <div class="text-sm text-gray-700 whitespace-pre-wrap">{{ item.transaction.notes }}</div>
-                                </div>
-                            } @else {
-                                <transaction-editor #editor [transaction]="item.transaction" [shouldShowTitle]="false" [shouldShowRefresh]="false"></transaction-editor>
-                            }
-                        </p-accordionTab>
+                            </p-accordion-header>
+                            <p-accordion-content>
+                                @if (item.hasError) {
+                                    <div class="p-4">
+                                        <div class="text-sm text-gray-700 whitespace-pre-wrap">{{ item.transaction.notes }}</div>
+                                    </div>
+                                } @else {
+                                    <transaction-editor #editor [transaction]="item.transaction" [shouldShowTitle]="false" [shouldShowRefresh]="false"></transaction-editor>
+                                }
+                            </p-accordion-content>
+                        </p-accordion-panel>
                     }
                 </p-accordion>
 

--- a/frontend/src/app/pages/transactions/transactions-import.component.ts
+++ b/frontend/src/app/pages/transactions/transactions-import.component.ts
@@ -43,12 +43,12 @@ interface TransactionItem {
     templateUrl: './transactions-import.component.html',
     styles: [
         `
-            :host ::ng-deep .validation-error .p-accordiontab-header {
+            :host ::ng-deep .validation-error .p-accordionheader {
                 border-left: 4px solid #ef4444 !important;
                 background-color: #fef2f2 !important;
             }
 
-            :host ::ng-deep .validation-error .p-accordiontab-header:hover {
+            :host ::ng-deep .validation-error .p-accordionheader:hover {
                 background-color: #fee2e2 !important;
             }
         `
@@ -77,7 +77,7 @@ export class TransactionsImportComponent implements OnInit {
     public showReview: boolean = false;
     public hideDuplicates: boolean = false;
     public showErrorsOnly: boolean = false;
-    public activeIndices: number[] = [];
+    public activeValues: string[] = [];
     public selectedFiles: File[] = [];
 
     @ViewChildren('editor') editors: QueryList<TransactionEditorComponent> = new QueryList();
@@ -422,10 +422,10 @@ export class TransactionsImportComponent implements OnInit {
         });
 
         if (hasValidationErrors) {
-            this.activeIndices = [];
+            this.activeValues = [];
             filteredItems.forEach((item, index) => {
                 if (item.hasValidationError) {
-                    this.activeIndices.push(index);
+                    this.activeValues.push(index.toString());
                 }
             });
 


### PR DESCRIPTION
## Summary
- Angular/PrimeNG 21 upgrade left the transactions import page broken: `<p-accordionTab>` and `pTemplate="header"` were removed, so review rows rendered flat (all expanded) and the staging-mode checkbox row layout broke.
- Port to `<p-accordion-panel>` / `<p-accordion-header>` / `<p-accordion-content>`; switch `[(activeIndex)]: number[]` to `[(value)]: string[]` with stringified panel values; update validation-error CSS to `.p-accordionheader`.
- Wrap each staging-mode checkbox + label in `flex items-center gap-2`; switch `id` to `inputId` so `<label for>` toggles the underlying input.

## Test plan
- [x] `ng build` clean
- [ ] Open Transactions Import page, verify checkbox row (Staging Mode + others) renders with visible checkboxes
- [ ] Parse a file in Staging Mode → review rows render collapsed; click expands one panel
- [ ] Trigger validation error on a selected row → that panel auto-expands and shows the red border
- [ ] Toggle Hide Duplicates / Errors Only filters → list updates correctly